### PR TITLE
Add `#include <wait.h>`.

### DIFF
--- a/fork_wait_exec/dish.cpp
+++ b/fork_wait_exec/dish.cpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include <unistd.h>
+#include <wait.h>
 
 using namespace std;
 


### PR DESCRIPTION
On Linux machines, `g++` would give error if we don't add `#include <wait.h>`.

```sh
$ g++ dish.cpp -o dish
dish.cpp: In function ‘int main(int, char**)’:
dish.cpp:28:22: error: ‘wait’ was not declared in this scope
   28 |     pid_t ret_wait = wait(NULL);
```